### PR TITLE
11 fix elasticsearch and update crawler info handling

### DIFF
--- a/crawler/config-crawler.yaml
+++ b/crawler/config-crawler.yaml
@@ -1,3 +1,4 @@
+# Only compatible with RSS 2.0 feeds
 crawlers:
 - company: line
   url: https://techblog.lycorp.co.jp/ko/feed/index.xml
@@ -7,4 +8,10 @@ crawlers:
   lastUpdated: 0
 - company: daangn
   url: https://medium.com/feed/daangn
+  lastUpdated: 0
+- company: kakao
+  url: https://tech.kakao.com/blog/feed
+  lastUpdated: 0
+- company: woowahan
+  url: https://techblog.woowahan.com/feed
   lastUpdated: 0

--- a/crawler/crawler.go
+++ b/crawler/crawler.go
@@ -64,7 +64,6 @@ func getTextSummary(stub *pb.CrawlerTextHandlerClient, posts *[]utils.Post, last
 		for {
 			res, err := stream.Recv()
 			if err == io.EOF {
-				logger.LogInfo("Received EOF")
 				close(doneChan)
 				return
 			}
@@ -120,8 +119,6 @@ func (c *Crawler) Run(stub *pb.CrawlerTextHandlerClient) {
 		logger.LogCrawlerResult(c.Company, postNumToUpdate, postNumUpdated)
 		return
 	}
-
-	lastIdxToUpdate = 0 // for test
 
 	// get text analysis results (grpc bidirectional)
 	var textInfos *[]TextSummarized = getTextSummary(stub, &posts, lastIdxToUpdate)

--- a/crawler/main.go
+++ b/crawler/main.go
@@ -26,12 +26,12 @@ func main() {
 
 	// run all crawlers
 	var wg sync.WaitGroup
-	for _, c := range crawlerArrayAddress.Crawlers {
+	for i := range crawlerArrayAddress.Crawlers {
 		wg.Add(1)
-		go func(crawler Crawler) {
+		go func(crawler *Crawler) {
 			defer wg.Done()
 			crawler.Run(&stub)
-		}(c)
+		}(&crawlerArrayAddress.Crawlers[i])
 	}
 	wg.Wait() // wait until all crawlers end
 

--- a/crawler/utils/logger.go
+++ b/crawler/utils/logger.go
@@ -53,6 +53,10 @@ func (l *Logger) LogInfo(message string) {
 	l.logger.Info(message)
 }
 
+func (l *Logger) LogDebug(message string) {
+	l.logger.Debug(message)
+}
+
 func (l *Logger) LogHttpResponseError(resp *http.Response) {
 	l.logger.Error("HTTP response error", slog.Int("Status Code", resp.StatusCode))
 }


### PR DESCRIPTION
## #️⃣ Related Issues
- This closes #11

## 📝 Work Details

- Fix: handle duplicate document scenarios
  - Replace esapi.IndexRequest with es.Create for duplicate document scenarios
  - Log duplicate document attempts with post link and document ID
- Fix: crawler info update handling
  - Modified crawler info structure to use pointer types for real-time updates
- Tested and verified changes with scenarios including potential duplicate posts and crawler info updates
- Chore: update comments and remove unnecessary logging