### PR TITLE
45 feature integrate elasticache for query caching in opensearch

### DIFF
--- a/serverless/apis/search/go.mod
+++ b/serverless/apis/search/go.mod
@@ -27,9 +27,12 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.28.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.32.2 // indirect
 	github.com/aws/smithy-go v1.22.0 // indirect
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
+	github.com/go-redis/redis/v8 v8.11.5 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/klauspost/compress v1.17.2 // indirect

--- a/serverless/apis/search/go.sum
+++ b/serverless/apis/search/go.sum
@@ -48,9 +48,13 @@ github.com/aws/aws-xray-sdk-go v1.8.4/go.mod h1:mbN1uxWCue9WjS2Oj2FWg7TGIsLikxMO
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.22.0 h1:uunKnWlcoL3zO7q+gG2Pk53joueEOsnNB28QdMsmiMM=
 github.com/aws/smithy-go v1.22.0/go.mod h1:irrKGvNn1InZwb2d7fkIRNucdfwR8R+Ts3wxYa/cJHg=
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/gabriel-vasile/mimetype v1.4.3 h1:in2uUcidCuFcDKtdcBxlR0rJ1+fsokWf+uqxgUFjbI0=
 github.com/gabriel-vasile/mimetype v1.4.3/go.mod h1:d8uq/6HKRL6CGdk+aubisF/M5GcPfT7nKyLpA0lbSSk=
 github.com/go-playground/assert/v2 v2.2.0 h1:JvknZsQTYeFEAhQwI4qEt9cyV5ONwRHC+lYKSsYSR8s=
@@ -61,6 +65,8 @@ github.com/go-playground/universal-translator v0.18.1 h1:Bcnm0ZwsGyWbCzImXv+pAJn
 github.com/go-playground/universal-translator v0.18.1/go.mod h1:xekY+UJKNuX9WP91TpwSH2VMlDf28Uj24BCp08ZFTUY=
 github.com/go-playground/validator/v10 v10.22.1 h1:40JcKH+bBNGFczGuoBYgX4I6m/i27HYW8P9FDk5PbgA=
 github.com/go-playground/validator/v10 v10.22.1/go.mod h1:dbuPbCMFw/DrkbEynArYaCwl3amGuJotoKCe95atGMM=
+github.com/go-redis/redis/v8 v8.11.5 h1:AcZZR7igkdvfVmQTPnu9WE37LRrO/YrBH5zWyjDC0oI=
+github.com/go-redis/redis/v8 v8.11.5/go.mod h1:gREzHqY1hg6oD9ngVRbLStwAWKhA0FEgq8Jd4h5lpwo=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=

--- a/serverless/apis/search/internal/utils/validator.go
+++ b/serverless/apis/search/internal/utils/validator.go
@@ -31,15 +31,7 @@ type SearchParams struct {
 	Size     int      `validate:"min=1,max=30"`
 }
 
-func ValidateParams(hashtags []string, company, query string, page, size int) error {
-	params := SearchParams{
-		Hashtags: hashtags,
-		Company:  company,
-		Query:    query,
-		Page:     page,
-		Size:     size,
-	}
-
+func ValidateParams(params SearchParams) error {
 	if err := validate.Struct(params); err != nil {
 		if _, ok := err.(*validator.InvalidValidationError); ok {
 			return fmt.Errorf("invalid validation error")


### PR DESCRIPTION
## #️⃣ Related Issues
- This closes #45

## 📝 Work Details
This pull request implements a caching strategy for the search API by integrating ElastiCache (Redis) to optimize performance and reduce the load on OpenSearch. The following changes have been made:

- **Caching Logic:** Added logic to check Redis for cached search results before querying OpenSearch. If a cache hit occurs, the results are returned directly from Redis.
- **Cache Key Generation:** Implemented a method to generate unique cache keys based on search parameters, ensuring that each unique query is cached appropriately.
- **Cache Expiration:** Configured cache expiration to align with the daily execution of the crawler at 19:00 KST, ensuring that cached data remains valid until the next data refresh.
- **X-Ray Integration:** Integrated AWS X-Ray for tracing and monitoring. This allows us to observe the performance of cache reads, database queries, and cache writes, enhancing our ability to troubleshoot and optimize.

### Performance Comparison
To illustrate the impact of this caching implementation, I have included captures from our APM tool showing API response times before and after applying caching:

- **Before Caching:** 
![image](https://github.com/user-attachments/assets/0ebfb8c6-5e1c-4974-81cd-4119b1838b1a)

- **After Cache Hit:** 
![image](https://github.com/user-attachments/assets/9db7d941-3db8-4b7e-a585-f095f140d47c)

In particular, for the slowest API(search API with no query params), the response time was reduced from 4.24 seconds to just 1 millisecond after implementing caching. This dramatic improvement demonstrates the effectiveness of our caching strategy, significantly enhancing user experience and reducing load on OpenSearch.